### PR TITLE
Bugfix/SUPPORT-2373 - Fixed ReactJS FusionCharts does not work in StrictMode

### DIFF
--- a/src/ReactFC.js
+++ b/src/ReactFC.js
@@ -4,6 +4,7 @@ import * as utils from './utils/utils';
 import fusionChartsOptions from './utils/options';
 
 class ReactFC extends React.Component {
+  initialUnmount = false;
   static fcRoot(core, ...modules) {
     modules.forEach(m => {
       if ((m.getName && m.getType) || (m.name && m.type)) {
@@ -35,7 +36,8 @@ class ReactFC extends React.Component {
   }
 
   componentWillUnmount() {
-    this.chartObj.dispose();
+    if (!this.initialUnmount) this.initialUnmount = true;
+    else this.chartObj.dispose();    
   }
 
   detectChanges(nextProps) {


### PR DESCRIPTION
Cause : dispose method was getting called one extra time in componentWillUnmount method in the strict mode which was causing setChartData function (in fusion charts constructor) run an extra time with unexpected arguments in case of rendering a map.
Solution : prevented the extra call to dispose method.